### PR TITLE
standard stuff:

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 
 #### General
 
-- [ ] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)
+- [ ] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 - [ ] Update README with any necessary configuration snippets
 

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ mkmf.log
 .DS_Store
 .idea/*
 *.gem
+*.swp

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 cache:
 - bundler
 before_install:
-  gem install bundler -v 1.15
+- gem install bundler -v 1.15
 install:
 - bundle install
 rvm:
@@ -18,20 +18,16 @@ notifications:
     on_success: change
     on_failure: always
 script:
+- gem build sensu-plugins-microsoft-teams.gemspec
+- gem install sensu-plugins-microsoft-teams-*.gem
 - bundle exec rake default
-- gem build sensu-plugins-skel.gemspec
-- gem install sensu-plugins-skel-*.gem
 deploy:
   provider: rubygems
   api_key:
-    secure: <encrypted rubygems deploy key>
-  gem: sensu-plugins-skel
+    secure: ld/He5yJQr2vlx3mMNPbrMLYizzBuuyuLS8zff+KV8YRCv9y94t82EeLA3V/GBAceZYUVgnk9aeL73p8up32nWnJlbPIZNdly9lPI4XqDPf0yUSPUOz6D54dki9NtPvz0al6zz1GBRuH9XhSuRFoWEfgTOrzcCneG++u23ZnaLwAEyBQ/vKnn8garfcA84ZPAA4lw3yjMfTZ3aNvU1ssbllKZQ8skcX3MtBK0ZEX50cShQKvGVTjb2YTNuJ31rj3jX1F2MF9BgLJs2odMhcRCrsBp4XG7Y/bYuvTHz0ygArPBlK4o0yFMjyExseGniCJk8dHpdja5Q44GWLhos70t7vz/nPe83SPtA9lB+TPt7hvVuJYhpJUGlt3/9HASaB34XieOPA745xhgdHlkJv5JUy2L+cbs1jux02gGcFHxL+9uAP+V+UtYpu7nOPS4j5xCh/qMItIby44ArmOhdRnCt/Bp7I9z+SpIjezL4B4JB76x7hGeBkEHjls171aIcSd6/88a4dLqLsw07SJ33+f4ONmf2RKQAXQPLWm6XzGHIXV9aB4Osao8vz41QVA48ejCClJO9/VN0fIZDp9d4IZZNcbYtcgi1j5hbN/1FjdbVnvf6qnXYqJ+QF5vHwnFTNkZauScRB1v6cMVqB9wTJeeqtIR7T46kHM1EP1+oNo6pU=
+  gem: sensu-plugins-microsoft-teams
   on:
     tags: true
     all_branches: true
-    rvm: 2.0
-    rvm: 2.1
-    rvm: 2.2
-    rvm: 2.3.0
     rvm: 2.4.1
-    repo: sensu-plugins/sensu-plugins-skel
+    repo: sensu-plugins/sensu-plugins-microsoft-teams

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,74 @@
 # Change Log
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
+This CHANGELOG follows the format located [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
-## Unreleased
+## [Unreleased]
+
 ### Added
-- Basic Skel to be used to make new plugin repo setup easier.
-- PR template
-- Rubocop config
+- gitignore (@majormoses)
+- rubycop config (@majormoses)
+
+### Changed
+- update changelog guidelines location (@majormoses)
+- travis config for testing and deploment to rubygems (@majormoses)
+
+## [1.2.2]
+### Changed
+- removed references in README to `skel` (@tuxpower)
+
+### Added
+- usage for  `handler-microsoft-teams.rb` (@tuxpower)
+
+## [1.2.1]
+### Breaking Changes
+- removed optional `clientkeys` fields (@tuxpower)
+
+## [1.2.0]
+### Added
+- OpenUri action type (@tuxpower)
+
+## [1.1.0]
+### Added
+- activityImage option (@tuxpower)
+
+## [1.0.0]
+- working version (@tuxpower)
+
+## [0.0.6]
+### Added
+- adapting code from slack plugin as reference (@tuxpower)
+
+## [0.0.5]
+### Changed
+- mulligan (@tuxpower)
+
+## [0.0.4]
+### Fixed
+- use `teams_url` over `webhook_url` (@tuxpower)
+
+## [0.0.3]
+### Fixed
+- updated references of `Slack` to `MicrosoftTeams` (@tuxpower)
+
+## [0.0.2]
+### Added
+- handler-microsoft-teams.rb: handler to send events to microsoft teams (@tuxpower)
+
+## [0.0.1]
+### Changed
+- updated references of `skel` to `microsoft-teams` (@tuxpower)
+
+
+[Unreleased]: https://github.com/sensu-plugins/sensu-plugins-microsoft-teams/compare/v1.2.2...HEAD
+[1.2.2]: https://github.com/sensu-plugins/sensu-plugins-microsoft-teams/compare/v1.2.1...v1.2.2
+[1.2.1]: https://github.com/sensu-plugins/sensu-plugins-microsoft-teams/compare/v1.2.0...v1.2.1
+[1.2.0]: https://github.com/sensu-plugins/sensu-plugins-microsoft-teams/compare/v1.1.0...v1.2.0
+[1.1.0]: https://github.com/sensu-plugins/sensu-plugins-microsoft-teams/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/sensu-plugins/sensu-plugins-microsoft-teams/compare/v0.0.6...v1.0.0
+[0.0.6]: https://github.com/sensu-plugins/sensu-plugins-microsoft-teams/compare/v0.0.5...v0.0.6
+[0.0.5]: https://github.com/sensu-plugins/sensu-plugins-microsoft-teams/compare/v0.0.4...v0.0.5
+[0.0.4]: https://github.com/sensu-plugins/sensu-plugins-microsoft-teams/compare/v0.0.3...v0.0.4
+[0.0.3]: https://github.com/sensu-plugins/sensu-plugins-microsoft-teams/compare/v0.0.1...v0.0.3
+[0.0.2]: https://github.com/sensu-plugins/sensu-plugins-microsoft-teams/compare/v0.0.1...v0.0.2
+[0.0.1]: https://github.com/sensu-plugins/sensu-plugins-microsoft-teams/compare/0b2d68b64a3d100c10da5e4cfce42206b9f22250...v0.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@ This CHANGELOG follows the format located [here](https://github.com/sensu-plugin
 
 ### Added
 - gitignore (@majormoses)
-- rubycop config (@majormoses)
+- rubocop config (@majormoses)
 
 ### Changed
 - update changelog guidelines location (@majormoses)
 - travis config for testing and deploment to rubygems (@majormoses)
+- handler-microsoft-teams.rb: appease the cops (@majormoses)
 
 ## [1.2.2]
 ### Changed

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 Sensu Community Plugins
+Copyright (c) 2016-2017 Sensu Community Plugins
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -19,4 +19,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-

--- a/bin/handler-microsoft-teams.rb
+++ b/bin/handler-microsoft-teams.rb
@@ -123,14 +123,14 @@ class MicrosoftTeams < Sensu::Handler
     template = if message_template && File.readable?(message_template)
                  File.read(message_template)
                else
-                 '''<%=
+                 '<%=
                  [
                    @event["check"]["output"].gsub(\'"\', \'\\"\'),
                    @event["client"]["address"],
                    @event["client"]["subscriptions"].join(",")
                  ].join(" : ")
                  %>
-                 '''
+                 '
                end
     eruby = Erubis::Eruby.new(template)
     eruby.result(binding)
@@ -176,11 +176,11 @@ class MicrosoftTeams < Sensu::Handler
         text: [teams_message_prefix, notice].compact.join(' ')
       }],
       potentialAction: [{
-        '@type': teams_action_type ? teams_action_type : "OpenUri",
-        name: teams_action_name ? teams_action_name : "View in Sensu",
+        '@type' => teams_action_type ? teams_action_type : 'OpenUri',
+        name: teams_action_name ? teams_action_name : 'View in Sensu',
         targets: [{
-          os: "default",
-          uri: "#{incident_key}" 
+          os: 'default',
+          uri: incident_key.to_s
         }]
       }]
     }.tap do |payload|


### PR DESCRIPTION
- readme
- changelog
- rakefile
- gemspec
- rubocop
- PR templates
- travis
- rubygems

I see rubocop failing and I think it has something to do with a hash key with `@` but I wanted to just get the bulk of stuff taken care of and we can circle back to that later.

Signed-off-by: Ben Abrams <me@benabrams.it>

## Pull Request Checklist

closes #1 

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass


#### Purpose
Finish standard setup after accepting new plugin into the community.
#### Known Compatibility Issues
