### PR TITLE
some cleanaup work

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,3 +28,6 @@ RegexpLiteral:
 
 Style/Documentation:
   Enabled: false
+
+AllCops:
+  TargetRubyVersion: 2.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,6 @@ before_install:
 install:
 - bundle install
 rvm:
-- 2.0
-- 2.1
-- 2.2
 - 2.3.0
 - 2.4.1
 notifications:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ This CHANGELOG follows the format located [here](https://github.com/sensu-plugin
 
 ## [Unreleased]
 
+### Security
+- updated `yard` dependency to `~> 0.9.11` per: https://nvd.nist.gov/vuln/detail/CVE-2017-17042 which closes attacks against a yard server loading arbitrary files (@majormoses)
+- updated rubocop dependency to `~> 0.51.0` per: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8418. (@majormoses)
+
+### Breaking Changes
+- removed ruby versions `< 2.3` support (@majormoses)
+- bumped `sensu-plugin` to `~> 2.7` which removes in handler event filtering you can read about it  [here](https://github.com/sensu-plugins/sensu-plugin/blob/master/CHANGELOG.md#v145---2017-03-07)(@majormoses)
+
+### Fixed
+- fix `handler-microsoft-teams.rb`: rescue any non sensu specification compliant status code passed to the microsoft-teams handler as the color matching `unknown` (@majormoses)
+
+### Changed
+- appeased the cops (@majormoses)
+
 ## [1.3.1] - 2018-09-12
 ### Fixed
 - Add erubis gem as a startup dependency (@asachs01)

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 require 'github/markup'
 require 'redcarpet'

--- a/bin/handler-microsoft-teams.rb
+++ b/bin/handler-microsoft-teams.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 # Copyright 2017 Jose Gaspar and contributors.
 #
@@ -199,7 +200,21 @@ class MicrosoftTeams < Sensu::Handler
       2 => '#FF0000',
       3 => '#6600CC'
     }
-    color.fetch(check_status.to_i)
+    # a script can return any error code it feels like we should not assume
+    # that it will always be 0,1,2,3 even if that is the sensu (nagions)
+    # specification. A couple common examples:
+    # 1. A sensu server schedules a check on the instance but the command
+    # executed does not exist in your `$PATH`. Shells will return a `127` status
+    # code.
+    # 2. Similarly a `126` is a permission denied or the command is not
+    # executable.
+    # Rather than adding every possible value we should just treat any non spec
+    # designated status code as `unknown`s.
+    begin
+      color.fetch(check_status.to_i)
+    rescue KeyError
+      color.fetch(3)
+    end
   end
 
   def check_status
@@ -213,6 +228,11 @@ class MicrosoftTeams < Sensu::Handler
       2 => :CRITICAL,
       3 => :UNKNOWN
     }
-    status[check_status.to_i]
+    begin
+      status[check_status.to_i]
+    # handle any non standard check status as `unknown`
+    rescue KeyError
+      status.fetch(3)
+    end
   end
 end

--- a/lib/sensu-plugins-microsoft-teams.rb
+++ b/lib/sensu-plugins-microsoft-teams.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 require 'sensu-plugins-microsoft-teams/version'

--- a/lib/sensu-plugins-microsoft-teams/version.rb
+++ b/lib/sensu-plugins-microsoft-teams/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SensuPluginsMicrosoftTeams
   module Version
     MAJOR = 1

--- a/sensu-plugins-microsoft-teams.gemspec
+++ b/sensu-plugins-microsoft-teams.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
@@ -22,13 +24,13 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.platform               = Gem::Platform::RUBY
   s.post_install_message   = 'You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu'
   s.require_paths          = ['lib']
-  s.required_ruby_version  = '>= 2.0.0'
+  s.required_ruby_version  = '>= 2.3.0'
   s.summary                = 'Sensu plugins for interfacing with Microsoft Teams'
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsMicrosoftTeams::Version::VER_STRING
 
   s.add_runtime_dependency 'erubis', '~> 2.7'
-  s.add_runtime_dependency 'sensu-plugin', '~> 1.2'
+  s.add_runtime_dependency 'sensu-plugin', '~> 2.7'
 
   s.add_development_dependency 'bundler',                   '~> 1.15'
   s.add_development_dependency 'github-markup',             '~> 1.3'
@@ -37,5 +39,5 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.add_development_dependency 'redcarpet',                 '~> 3.2'
   s.add_development_dependency 'rspec',                     '~> 3.4'
   s.add_development_dependency 'rubocop',                   '~> 0.49.0'
-  s.add_development_dependency 'yard',                      '~> 0.8'
+  s.add_development_dependency 'yard',                      '~> 0.9.11'
 end


### PR DESCRIPTION
CVES:
- https://nvd.nist.gov/vuln/detail/CVE-2017-17042
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8418

Breaking Changes:
- removing ruby `< 2.3` support

Fixes:
- backported a fix from the slack handler I made in https://github.com/sensu-plugins/sensu-plugins-slack/pull/62 as I realized it shared the same code. I am thinking going forward it might be nice to have that be part of the `sensu-plugin` class so it could be available to all plugins without having a bunch of shared code.

Misc Updates:
- appeased the cops
-

Signed-off-by: Ben Abrams <me@benabrams.it>

## Pull Request Checklist

Yes:
- https://github.com/sensu-plugins/community/issues/97
- https://github.com/sensu-plugins/community/issues/77

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass


#### Purpose
Address several known security issues and backporting a change made to the slack handler.


#### Known Compatibility Issues
Breaks compatibility with ruby versions `< 2.3`